### PR TITLE
32 fix files buttons

### DIFF
--- a/fridacli/chatbot/__init__.py
+++ b/fridacli/chatbot/__init__.py
@@ -1,10 +1,8 @@
 import re
 import textdistance as td
-
 from softtek_llm.models import SofttekOpenAI
 from softtek_llm.memory import WindowMemory
 from softtek_llm.chatbots.chatbot import Chatbot
-
 from .predefined_phrases import (
     chatbot_unauthorized,
     chatbot_badrequest,
@@ -19,6 +17,7 @@ from fridacli.config import get_config_vars
 from fridacli.prompts_provider.chatbot_prompts import system_prompt
 from fridacli.file_manager import FileManager
 from fridacli.logger import Logger
+from fridacli.config import SUPPORTED_PROGRAMMING_LANGUAGES
 
 logger = Logger()
 
@@ -51,8 +50,7 @@ class ChatbotAgent:
 
     def is_file_format(self, word):
         # Determine if a word follows the file format (name.extension).
-        extensions = [".py", ".asp"]
-        pattern = f'^[a-zA-Z_][a-zA-Z0-9_]*({ "|".join(extensions)})$'
+        pattern = f'^[a-zA-Z_][a-zA-Z0-9_]*({ "|".join(SUPPORTED_PROGRAMMING_LANGUAGES)})$'
         match = re.match(pattern, word)
         return bool(match)
 

--- a/fridacli/config.py
+++ b/fridacli/config.py
@@ -6,6 +6,25 @@ HOME_PATH = os.path.expanduser("~")
 OS = "win" if sys.platform.startswith('win') else "linux"
 config_file_path = f"{HOME_PATH}/.fridacli"
 BOT_NAME = "Frida"
+SUPPORTED_PROGRAMMING_LANGUAGES = [
+    ".py",
+    ".asp",
+    ".java",
+    ".cpp",
+    ".c",
+    ".cs",
+    ".js",
+    ".html",
+    ".css",
+    ".php",
+    ".rb",
+    ".swift",
+    ".go",
+    ".lua",
+    ".pl",
+    ".r",
+    ".sh",
+]
 
 if OS == "linux":
     import pwd

--- a/fridacli/frida_coder/__init__.py
+++ b/fridacli/frida_coder/__init__.py
@@ -2,7 +2,7 @@ import os
 import re
 import datetime
 from fridacli.frida_coder.languague.python import Python
-from fridacli.config import HOME_PATH
+from fridacli.config import HOME_PATH, SUPPORTED_PROGRAMMING_LANGUAGES
 from .exception_message import ExceptionMessage
 from fridacli.file_manager import FileManager
 from fridacli.logger import Logger
@@ -161,22 +161,4 @@ class FridaCoder:
         self.code_blocks = []
 
     def is_programming_language_extension(self, extension: str):
-        programming_language_extensions = [
-            ".py",
-            ".asp" ".java",
-            ".cpp",
-            ".c",
-            ".cs",
-            ".js",
-            ".html",
-            ".css",
-            ".php",
-            ".rb",
-            ".swift",
-            ".go",
-            ".lua",
-            ".pl",
-            ".r",
-            ".sh",
-        ]
-        return extension.lower() in programming_language_extensions
+        return extension.lower() in SUPPORTED_PROGRAMMING_LANGUAGES

--- a/fridacli/gui/chat_view.py
+++ b/fridacli/gui/chat_view.py
@@ -11,6 +11,7 @@ from fridacli.logger import Logger
 from textual.events import Mount
 from rich.syntax import Syntax
 from fridacli.config import OS
+import os
 
 logger = Logger()
 
@@ -130,8 +131,9 @@ class ChatView(Static):
         """Event when a button in clicked"""
         button_pressed = str(event.button.id)
         if "cv_hs_file_" in button_pressed:
-            file_name = button_pressed.replace("cv_hs_file_", "")
-            convert_file_name = file_name.replace("-", ".")
-            logger.info(__name__, f"convert_file_name: {convert_file_name}")
-            path = self.file_manager.get_file_path(convert_file_name)
+            id = int(button_pressed.split("_")[-1])
+            file_name = self.mentioned_files[id]
+            logger.info(__name__, f"convert_file_name: {file_name}")
+            path = self.file_manager.get_file_path(file_name)
+            logger.info(__name__, f"{path} {file_name}")
             self.display_code_file(path)


### PR DESCRIPTION
Fix:

- When a chat is started, the buttons to open files are created and displayed
- Creates a button for all the files mentioned in the chat
- When deleting or writing a file name, all buttons are updated

New:

- Add a global variable that handles the supported coding file extensions.